### PR TITLE
create a yaml version of the "policy mapping" tab in the excel file

### DIFF
--- a/Open-Source-Policy-Templates/ISO-IEC-5230-(OpenChain 2.1)/en/referenced_policy_template.yml
+++ b/Open-Source-Policy-Templates/ISO-IEC-5230-(OpenChain 2.1)/en/referenced_policy_template.yml
@@ -899,8 +899,7 @@
   Foundations Specific: ''
 - order: 74
   OCS Section: 3.5
-  OpenChain Specification v2.1, ISO/IEC 5230:2020: "Understand open Source community"
-    engagement
+  OpenChain Specification v2.1, ISO/IEC 5230:2020: "Understand open Source community engagement"
   Category: H
   Q No.: ''
   Conformance Questions: ''
@@ -992,8 +991,7 @@
   Foundations Specific: ''
 - order: 81
   OCS Section: 3.6
-  OpenChain Specification v2.1, ISO/IEC 5230:2020: "Adherence to the Specification"
-    Requirements
+  OpenChain Specification v2.1, ISO/IEC 5230:2020: "Adherence to the Specification Requirements"
   Category: H
   Q No.: ''
   Conformance Questions: ''


### PR DESCRIPTION
I needed a way to both preserve the OCS reference in the policy text and to track modifications via git diff, commit or else, in a git repository and then having only one policy text source. The most readable yet efficient way (HT @alpianon who has done the heavy lifting) was a YAML, that basically can be treated as a markdown. 